### PR TITLE
Adaptação para build automático no Jenkins.

### DIFF
--- a/GitRepo.js
+++ b/GitRepo.js
@@ -46,7 +46,6 @@ GitRepo.prototype.token = function(){
 GitRepo.prototype.commits = function(reference_to,reference_from){
 	var uri = util.format(REPOSITORY_COMMITS_URI,this.repositoryOwner,this.repositoryName,reference_to,reference_from);
 	var that = this;
-
 	const commitArray = [];
 	return resolveCommits(uri, that, commitArray);
 }
@@ -55,7 +54,6 @@ var resolveCommits = function(uri, that, commitArray) {
 	if(!commitArray) commitArray = [];
 	return new Promise(function(resolve,reject){
 		that._request(uri).then(function(body){
-
  			var commits = GitRepo._parse_commits(body);
 			if (commits.length===0){
 				reject(logger.warn("no commit found for this release"));
@@ -149,16 +147,14 @@ GitRepo._parse_diff = function(diff){
 
 GitRepo._parse_commits = function(body){
 
-	 body = JSON.parse(body);
+	body = JSON.parse(body);
 
 	if (body.type === "error"){
 		throw new Error(body.error.message);
 	}
 
-
 	var _commits = body.values;
 	var commits = [];
-
 
 	for (var i = 0, len = _commits.length; i < len; i++) {
 	  var _commit = _commits[i];

--- a/GitRepo.js
+++ b/GitRepo.js
@@ -46,6 +46,7 @@ GitRepo.prototype.token = function(){
 GitRepo.prototype.commits = function(reference_to,reference_from){
 	var uri = util.format(REPOSITORY_COMMITS_URI,this.repositoryOwner,this.repositoryName,reference_to,reference_from);
 	var that = this;
+
 	const commitArray = [];
 	return resolveCommits(uri, that, commitArray);
 }
@@ -54,6 +55,7 @@ var resolveCommits = function(uri, that, commitArray) {
 	if(!commitArray) commitArray = [];
 	return new Promise(function(resolve,reject){
 		that._request(uri).then(function(body){
+
  			var commits = GitRepo._parse_commits(body);
 			if (commits.length===0){
 				reject(logger.warn("no commit found for this release"));
@@ -147,14 +149,16 @@ GitRepo._parse_diff = function(diff){
 
 GitRepo._parse_commits = function(body){
 
-	body = JSON.parse(body);
+	 body = JSON.parse(body);
 
 	if (body.type === "error"){
 		throw new Error(body.error.message);
 	}
 
+
 	var _commits = body.values;
 	var commits = [];
+
 
 	for (var i = 0, len = _commits.length; i < len; i++) {
 	  var _commit = _commits[i];

--- a/controllers/api.js
+++ b/controllers/api.js
@@ -1,5 +1,6 @@
 
 var GitRepo = require("../GitRepo.js");
+var _ = require("lodash");
 var logger = require("../logger/logger.js");
 var Promise = require("promise");
 
@@ -8,29 +9,35 @@ module.exports = function(app){
 	return {
 		release:{
 			post: function(req,res){
-
 				var body = req.body;
+				var releaseBody = _.pick(body,['release']);
 
-				var release = new app.models.Release();
+				var release = new app.models.Release(_.get(releaseBody, 'release'));
 
-				release.application = req.params.app_name;
-				release.environment = body.environment;
-				release.reference = body.reference;
-				release.name = body.name;
-
-				app.models.Application.findOne({name:release.application},{_id:false }).then(function(application){
+				app.models.Application.findOne({name:req.params.app_name},{_id:false }).then(function(application){
 					if (!application) {
-						errorHandler(`Application ${release.application} not found`, res, 404);
-						return;
+						var appBody = _.pick(body,['application']);
+						var application = new app.models.Application(_.get(appBody, 'application'));
+
+						logger.info(`Application ${application.name} not found, creating it...`);
+						application.save(function(err,application){
+							if (err){
+								errorHandler("Error when saving to MongoDB",err,400);
+								res.status(400);
+								res.end();
+								return;
+							}
+							logger.info(`Application ${application.name} created sucessfully!`)
+							res.location("/apps/" + application.name);
+						});
 					}
-					app.models.Release.findOne({name:release.name , application: release.application}).limit(1).then(function(targetRelease){
+					app.models.Release.findOne({name:release.name , application: application.name}).limit(1).then(function(targetRelease){
 						if (targetRelease) {
 							logger.info(`Release ${release.name} already exist!`)
 							res.status(200);
 							res.json(targetRelease)
 							return;
 						}else{
-
 							application.lastRelease().then(function(lastRelease){
 								release.compare = lastRelease;
 
@@ -146,7 +153,8 @@ module.exports = function(app){
 			post: function(req,res){
 
 				var body = req.body;
-				var application = new app.models.Application(body);
+				var appBody = _.pick(body,['application']);
+				var application = new app.models.Application(_.get(appBody, 'application'));
 
 				application.save(function(err,app){
 					if (err){

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ejs": "^2.5.6",
     "express": "^4.14.1",
     "express-load": "^1.1.15",
+    "lodash": "^4.17.4",
     "moment": "^2.17.1",
     "mongoose": "^4.8.5",
     "parse-diff": "^0.4.0",


### PR DESCRIPTION
Este PR contempla uma proposta de mudança onde, ao automatizar o cadastro com o jenkins, não precisaremos mais nos preocupar se a aplicação existe ou não. No caso da aplicação não existir, o sistema cria uma app com as informações passadas no payload.

Segue um exemplo de mudança:
```json
{
   "application":{
      "name":"foo-app",
      "milestone":"foo-2.0",
      "repository":{
         "name":"foo-app",
         "owner":"git-m4u"
      }
   },
   "release":{
      "name": "foo-2.0.2",
      "environment": "production",
      "reference": {
         "type": "git"
      }
   }
}
```

Desse jeito, não será nescessário realizar dois posts no jenkins (um para criar a aplicação, que na maioria das vezes é um post desnecessário e outro para a release).
